### PR TITLE
GetStoreHost behind reverse proxy

### DIFF
--- a/src/Libraries/Nop.Core/WebHelper.cs
+++ b/src/Libraries/Nop.Core/WebHelper.cs
@@ -79,7 +79,7 @@ namespace Nop.Core
         /// <returns>Result</returns>
         protected virtual bool IsIpAddressSet(IPAddress address)
         {
-            var rez =  address != null && address.ToString() != IPAddress.IPv6Loopback.ToString();
+            var rez = address != null && address.ToString() != IPAddress.IPv6Loopback.ToString();
 
             return rez;
         }
@@ -110,10 +110,10 @@ namespace Nop.Core
             if (!IsRequestAvailable())
                 return string.Empty;
 
-            if(_httpContextAccessor.HttpContext.Connection?.RemoteIpAddress is not IPAddress remoteIp)
+            if (_httpContextAccessor.HttpContext.Connection?.RemoteIpAddress is not IPAddress remoteIp)
                 return "";
 
-            if(remoteIp.Equals(IPAddress.IPv6Loopback))
+            if (remoteIp.Equals(IPAddress.IPv6Loopback))
                 return IPAddress.Loopback.ToString();
 
             return remoteIp.MapToIPv4().ToString();
@@ -174,6 +174,14 @@ namespace Nop.Core
             var hostHeader = _httpContextAccessor.HttpContext.Request.Headers[HeaderNames.Host];
             if (StringValues.IsNullOrEmpty(hostHeader))
                 return string.Empty;
+
+            var result = _httpContextAccessor
+                .HttpContext
+                .Request
+                .Headers
+                .TryGetValue("X-Forwarded-Proto", out var forwardProtoHeaders);
+
+            useSsl = result && forwardProtoHeaders.Any(a => a.Equals("https", StringComparison.InvariantCultureIgnoreCase));
 
             //add scheme to the URL
             var storeHost = $"{(useSsl ? Uri.UriSchemeHttps : Uri.UriSchemeHttp)}{Uri.SchemeDelimiter}{hostHeader.FirstOrDefault()}";
@@ -358,7 +366,7 @@ namespace Nop.Core
                 var response = _httpContextAccessor.HttpContext.Response;
                 //ASP.NET 4 style - return response.IsRequestBeingRedirected;
                 int[] redirectionStatusCodes = { StatusCodes.Status301MovedPermanently, StatusCodes.Status302Found };
-                
+
                 return redirectionStatusCodes.Contains(response.StatusCode);
             }
         }


### PR DESCRIPTION
When running NopCommerce behind a reverse proxy the image and javascript links are not properly generated with https.

This generates a mixed content error. Ajax calls on the checkout page fail. This will check if the request contains x-forwarded-proto